### PR TITLE
Fix issue with line break in citations field

### DIFF
--- a/citation_graph.py
+++ b/citation_graph.py
@@ -65,7 +65,7 @@ def main():
     for entry in bib_database.entries:
         if 'citations' in entry:
             print(entry['ID'])
-            for citation_id in entry['citations'].split(','):
+            for citation_id in entry['citations'].replace('\n', '').split(','):
                 print('   ' + citation_id)
                 if citation_id:
                     if cite_as_noun:


### PR DESCRIPTION
The following BibTeX entry, from [Wikipedia](https://en.wikipedia.org/wiki/BibTeX), is valid:

```
@Book{abramowitz+stegun,
 author    = "Milton {Abramowitz} and Irene A. {Stegun}",
 title     = "Handbook of Mathematical Functions with
              Formulas, Graphs, and Mathematical Tables",
 publisher = "Dover",
 year      =  1964,
 address   = "New York City",
 edition   = "ninth Dover printing, tenth GPO printing"
}
```

Note that values for BibTeX fields can be in more than one line. This is supported by bibtexparser and `\n` is included to represent the line break. If you have

```
  citations =    {foo,
                  bar}
```

the Python script will look for BibTeX IDs `foo` and `\nbar`. It will find the first but not the second. This pull request fix this issue by removing `n` so that the Python script searchers for `foo` and `bar` as BibTeX IDs.